### PR TITLE
Add stripMargin function.

### DIFF
--- a/test/Test/Data/String/Utils.purs
+++ b/test/Test/Data/String/Utils.purs
@@ -12,9 +12,9 @@ import Data.String.Utils         ( NormalizationForm(NFC), charAt, codePointAt
                                  , includes', length, lines, mapChars, normalize
                                  , normalize', repeat, replaceAll, startsWith
                                  , startsWith', stripChars, stripDiacritics
-                                 , toCharArray, trimEnd, trimStart
-                                 , unsafeCodePointAt, unsafeCodePointAt'
-                                 , unsafeRepeat, words
+                                 , stripMargin, stripMarginWith, toCharArray
+                                 , trimEnd, trimStart, unsafeCodePointAt
+                                 , unsafeCodePointAt', unsafeRepeat, words
                                  )
 import Effect                    (Effect)
 import Effect.Console            (log)
@@ -345,6 +345,49 @@ testStringUtils = do
   assert $ stripDiacritics "Raison d'être"   === "Raison d'etre"
   assert $ stripDiacritics "Týr"             === "Tyr"
   assert $ stripDiacritics "Zürich"          === "Zurich"
+
+  log "stripMarginWith"
+
+  assert $ stripMarginWith "@ " """@ Line 1
+                                   @ Line 2
+                                   @ Line 3"""
+                            == "Line 1\nLine 2\nLine 3"
+
+  assert $ stripMarginWith "@ " """Line 1
+                                 x@ Line 2
+                                   Line 3
+                                      @ Line 4
+                                  @ Line 5"""
+           == "Line 1\n                                 x@ Line 2\n                                   Line 3\nLine 4\nLine 5"
+
+  assert $ stripMarginWith ""
+    """
+    Line 1
+    Line 2
+    Line 3
+    """
+           == "Line 1\nLine 2\nLine 3"
+
+  log "stripMargin"
+
+  assert $ stripMargin """|Line 1
+                          |Line 2
+                          |Line 3"""
+           == "Line 1\nLine 2\nLine 3"
+
+  assert $ stripMargin """Line 1
+                         x|Line 2
+                           Line 3
+                              |Line 4
+                          |Line 5"""
+          == "Line 1\n                         x|Line 2\n                           Line 3\nLine 4\nLine 5"
+
+  assert $ stripMargin
+    """
+    |Line 1
+    |Line 2
+    |Line 3
+    """ == "Line 1\nLine 2\nLine 3"
 
   log "toCharArray"
   let


### PR DESCRIPTION
If you're familiar with Scala's [`stripMargin`](https://www.scala-lang.org/api/2.12.3/scala/collection/immutable/StringLike.html#stripMargin:String), this is a basic version of the same thing.

I thought it might be a good idea to add this to the library after seeing [this Stack Overflow post](https://stackoverflow.com/questions/52648205/strip-margin-of-indented-triple-quote-string-in-purescript).