### PR TITLE
fix: update to purs 0.14 -> remove already deprecated function replaceAll

### DIFF
--- a/src/Data/String/Utils.purs
+++ b/src/Data/String/Utils.purs
@@ -20,7 +20,6 @@ module Data.String.Utils
   , padStart
   , padStart'
   , repeat
-  , replaceAll
   , startsWith
   , startsWith'
   , stripChars
@@ -409,18 +408,6 @@ repeat n s = runFn4 repeatImpl Just Nothing n s
 
 foreign import repeatImpl
   :: Fn4 (∀ a. a -> Maybe a) (∀ a. Maybe a) Int String (Maybe String)
-
--- | DEPRECATED: This function is now available in `purescript-strings`.
--- |
--- | Replace all occurences of the first argument with the second argument.
-replaceAll
-  :: Warn (Text "DEPRECATED: `Data.String.Utils.replaceAll`")
-  => String -> String -> String -> String
-replaceAll = replace <<< mkRegex
-  where
-    -- Helper function to construct a `Regex` from an input string
-    mkRegex :: String -> Regex
-    mkRegex str = unsafePartial (fromRight (regex (escapeRegex str) global))
 
 -- | Determine whether the second argument starts with the first one.
 startsWith :: String -> String -> Boolean


### PR DESCRIPTION

in module Data.String.Utils
at .spago/stringutils/v0.0.10/src/Data/String/Utils.purs:423:19 - 423:77 (line 423, column 19 - line 423, column 77)

  Could not match type

    Either t1 (Either String Regex) -> Either String Regex

  with type

    Regex